### PR TITLE
Add support for PodSecurityPolicies, ServiceAccounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ helm install --name=kafka-minion kafka-minion/kafka-minion
 | `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | (none) |
 | `podAnnotations` | Pod annotations | `{}` |
 | `priorityClassName` | Priority Class to be used by the pod | `""` |
+| `podSecurityPolicy.enabled` | Enable/disable PodSecurityPolicy and associated Role/Rolebinding creation | `false` |
+| `serviceAccount.create` | Create a ServiceAccount for the pod | `false` |
+| `serviceAccount.name` | Name of a ServiceAccount to use that is not handled by this chart | `default` |
 
 ## SASL/SSL Setup
 

--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
         app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.create  }}
+      serviceAccountName: {{ include "kafka-minion.fullname" . }}
+      {{- else }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{ toYaml .Values.podSecurityContext | nindent 8 }}
@@ -44,7 +49,7 @@ spec:
           {{- if .Values.containerSecurityContext }}
           securityContext:
             {{ toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- end }} 
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:

--- a/kafka-minion/templates/podsecuritypolicies.yaml
+++ b/kafka-minion/templates/podsecuritypolicies.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kafka-minion.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
+    helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+   - ALL
+  volumes:
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+{{- end }}

--- a/kafka-minion/templates/role.yaml
+++ b/kafka-minion/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podSecurityPolicy.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ include "kafka-minion.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
+    helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "kafka-minion.fullname" . }}
+{{- end }}

--- a/kafka-minion/templates/rolebinding.yaml
+++ b/kafka-minion/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ include "kafka-minion.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
+    helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kafka-minion.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  {{- if .Values.serviceAccount.create  }}
+  name: {{ include "kafka-minion.fullname" . }}
+  {{- else }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/kafka-minion/templates/serviceaccount.yaml
+++ b/kafka-minion/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafka-minion.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
+    helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/kafka-minion/values.yaml
+++ b/kafka-minion/values.yaml
@@ -112,10 +112,21 @@ serviceMonitor:
   interval: 10s
   scrapeTimeout: 10s
   # By default, Prometheus Operator uses its own Release label as the selector for ServiceMonitors.
-  # Update this to match the release name of your Prometheus Operator installation if 
+  # Update this to match the release name of your Prometheus Operator installation if
   # you aren't using custom match labels on your Prometheus definition.
   releaseLabel: prometheus-operator
-  # Additional labels to add to the ServiceMonitor in case Prometheus Operator is configured with 
+  # Additional labels to add to the ServiceMonitor in case Prometheus Operator is configured with
   # different matchLabels configuration, to make sure it matches this ServiceMonitor.
   # If this is defined, the release label of the service monitor will match kube-eagle's one
   # additionalLabels:
+
+# Do not create a service account by default
+# Name allows using a service account not handled by the chart
+serviceAccount:
+  create: false
+  name: default
+
+# Creates a PodSecurityPolicy and the role/rolebinding
+# allowing the serviceaccount to use it
+podSecurityPolicy:
+  enabled: false


### PR DESCRIPTION
Hi,

This PR adds support for PodSecurityPolicies and ServiceAccounts.

They are not activated by default in order to avoid potentially breaking changes, and the `default` service account is the one used by default for the same reason.