### PR TITLE
Add support for defining key names used for existing SASL and TSL Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,18 @@ helm install --name=kafka-minion kafka-minion/kafka-minion
 | `kafka.brokers` | Comma delimited list of brokers to connect to | (none) |
 | `kafka.sasl.enabled` | Bool to enable/disable SASL authentication (only SASL_PLAINTEXT is supported) | `false` |
 | `kafka.sasl.useHandshake` | Whether or not to send the Kafka SASL handshake first | `true` |
-| `kafka.sasl.credentials.existingSecret` | Secretname of an existing secret which contains SASL credentials | (none) |
+| `kafka.sasl.existingSecret` | Secretname of an existing secret which contains SASL credentials | (none) |
+| `kafka.sasl.existing.usernameKey` | Keyname of an existing key on an existing secret which contains SASL username | `username` |
+| `kafka.sasl.existing.passwordKey` | Keyname of an existing key on an existing secret which contains SASL password | `password` |
 | `kafka.sasl.credentials.username` | SASL username | (none) |
 | `kafka.sasl.credentials.password` | SASL password | (none) |
 | `kafka.tls.enabled` | Whether or not to use TLS when connecting to the broker | `false` |
 | `kafka.tls.insecureSkipTlsVerify` | If true, TLS accepts any certificate presented by the server and any host name in that certificate. | `true` |
-| `kafka.tls.certificates.existingSecret` | Secretname of an existing secret which contains TLS certificates | (none) |
+| `kafka.tls.existingSecret` | Secretname of an existing secret which contains TLS certificates | (none) |
+| `kafka.tls.existing.caKey` | Keyname of an existing key on an existing secret which contains TLS CA | `tls.ca` |
+| `kafka.tls.existing.certKey` | Keyname of an existing key on an existing secret which contains TLS Cert | `tls.crt` |
+| `kafka.tls.existing.keyKey` | Keyname of an existing key on an existing secret which contains TLS Key | `tls.key` |
+| `kafka.tls.existing.passphraseKey` | Keyname of an existing key on an existing secret which contains Key to decrypt TLS key| `passphrase` |
 | `kafka.tls.certificates.ca` | TLS CA | (none) |
 | `kafka.tls.certificates.cert` | TLS Cert | (none) |
 | `kafka.tls.certificates.key` | TLS Key | (none) |
@@ -56,11 +62,11 @@ helm install --name=kafka-minion kafka-minion/kafka-minion
 
 ## SASL/SSL Setup
 
-When configuring SASL or TLS you can either provide the secretname of an existing secret **or** pass the contents as values. When you choose to create the secrets on your own, please make sure you comply with the key names used in this chart:
+When configuring SASL or TLS you can either provide the secretname of an existing secret **or** pass the contents as values. When you choose to create the secrets on your own, please make sure you comply with the key names defined in this chart:
 
 #### SASL
 
-Key names are `username` and `password`.
+Key names are `username` and `password` by default.
 
 ```yml
 type: Opaque
@@ -71,7 +77,7 @@ data:
 
 #### TLS
 
-Key names are `tls.ca`, `tls.key`, `tls.crt` and `passphrase`.
+Key names are `tls.ca`, `tls.key`, `tls.crt` and `passphrase` by default.
 
 ```yml
 type: Opaque

--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -78,12 +78,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ template "kafka-minion.saslSecretName" . }}"
-                  key: username
+                  key: {{ .Values.kafka.sasl.existing.usernameKey }}
             - name: KAFKA_SASL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: "{{ template "kafka-minion.saslSecretName" . }}"
-                  key: password
+                  key: {{ .Values.kafka.sasl.existing.passwordKey }}
             - name: KAFKA_SASL_USE_HANDSHAKE
               value: {{ .Values.kafka.sasl.useHandshake | quote }}
             {{- end }}
@@ -91,16 +91,16 @@ spec:
               value: {{ .Values.kafka.tls.enabled | quote }}
             {{- if .Values.kafka.tls.enabled }}
             - name: KAFKA_TLS_CA_FILE_PATH
-              value: /etc/kafka-secrets/tls.ca
+              value: /etc/kafka-secrets/{{ .Values.kafka.tls.existing.caKey }}
             - name: KAFKA_TLS_KEY_FILE_PATH
-              value: /etc/kafka-secrets/tls.key
+              value: /etc/kafka-secrets/{{ .Values.kafka.tls.existing.keyKey }}
             - name: KAFKA_TLS_CERT_FILE_PATH
-              value: /etc/kafka-secrets/tls.crt
+              value: /etc/kafka-secrets/{{ .Values.kafka.tls.existing.certKey }} 
             - name: KAFKA_TLS_PASSPHRASE
               valueFrom:
                 secretKeyRef:
                   name: "{{ template "kafka-minion.tlsSecretName" . }}"
-                  key: passphrase
+                  key: {{ .Values.kafka.tls.existing.passphraseKey }}
             - name: KAFKA_TLS_INSECURE_SKIP_TLS_VERIFY
               value: {{ .Values.kafka.tls.insecureSkipTlsVerify | quote }}
             {{- end }}

--- a/kafka-minion/values.yaml
+++ b/kafka-minion/values.yaml
@@ -80,6 +80,9 @@ kafka:
   consumerOffsetsTopic: __consumer_offsets
   sasl:
     enabled: false
+    existing:
+      usernameKey: username
+      passwordKey: password
     useHandshake: true
     credentials: {}
       # You can either create the secret yourself or let the helm chart create one for you.
@@ -91,6 +94,11 @@ kafka:
       # password: securePass123
   tls:
     enabled: false
+    existing:
+      caKey: tls.ca
+      certKey: tls.crt
+      keyKey: tls.key
+      passphraseKey: passphrase
     insecureSkipTlsVerify: true
     certificates: {}
       # You can either create the secret yourself or let the helm chart create one for you.


### PR DESCRIPTION
- Add support for defining key names used for existing SASL and TSL Secrets. This is useful when the existing secrets are generated from a different system, such as Strimzi.

  - Ideally the path for `existingSecret` should be changed to fit under the `kafka.{x}.existing` path, but I left it where it is currently at to not break backwards compatibility. 

- Fix documentation for SASL and TSL existingSecret paths. I found that the existing documented paths `kafka.sasl.credentials.existingSecret` and `kafka.tls.certificates.existingSecret` are incorrect and instead should be `kafka.sasl.existingSecret` and `kafka.tls.existingSecret` respectively. These are used within the `templates/_helpers.tpl` file.