### PR TITLE
Do not create Prometheus scrape annotations when serviceMonitor is used

### DIFF
--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -19,9 +19,11 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if eq .Values.serviceMonitor.create false }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.telemetry.port | quote }}
         prometheus.io/path: "/metrics"
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if eq .Values.serviceMonitor.create false }}
+        {{- if not .Values.serviceMonitor.create }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.telemetry.port | quote }}
         prometheus.io/path: "/metrics"


### PR DESCRIPTION
This avoids double scraping when Prometheus ServiceMonitor is used (1. via annotations, the other via ServiceMonitor)