### PR TITLE
Add namespace metadata to all k8s resource definitions

### DIFF
--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/ingress.yaml
+++ b/kafka-minion/templates/ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/podsecuritypolicies.yaml
+++ b/kafka-minion/templates/podsecuritypolicies.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/role.yaml
+++ b/kafka-minion/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/rolebinding.yaml
+++ b/kafka-minion/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/sasl-secret.yaml
+++ b/kafka-minion/templates/sasl-secret.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "kafka-minion.saslSecretName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "kafka-minion.name" . }}
     chart: {{ include "kafka-minion.chart" . }}
@@ -10,7 +12,6 @@ metadata:
     {{- if .Values.extraLabels }}
     {{ toYaml .Values.extraLabels | nindent 4 }}
     {{- end }}
-  name: {{ template "kafka-minion.saslSecretName" . }}
 type: Opaque
 data:
   username: {{ .Values.kafka.sasl.credentials.username | b64enc }}

--- a/kafka-minion/templates/service.yaml
+++ b/kafka-minion/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/serviceaccount.yaml
+++ b/kafka-minion/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}

--- a/kafka-minion/templates/servicemonitor.yaml
+++ b/kafka-minion/templates/servicemonitor.yaml
@@ -3,6 +3,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  name: {{ include "kafka-minion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "kafka-minion.name" . }}
     chart: {{ template "kafka-minion.chart" . }}
@@ -17,7 +19,6 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
 {{- end }}
-  name: {{ template "kafka-minion.fullname" . }}
 spec:
   endpoints:
   - interval: {{ .Values.serviceMonitor.interval }}

--- a/kafka-minion/templates/tls-secret.yaml
+++ b/kafka-minion/templates/tls-secret.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "kafka-minion.tlsSecretName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "kafka-minion.name" . }}
     chart: {{ include "kafka-minion.chart" . }}
@@ -10,7 +12,6 @@ metadata:
     {{- if .Values.extraLabels }}
     {{ toYaml .Values.extraLabels | nindent 4 }}
     {{- end }}
-  name: {{ template "kafka-minion.tlsSecretName" . }}
 type: Opaque
 data:
   tls.ca: {{ .Values.kafka.tls.certificates.ca | b64enc }}


### PR DESCRIPTION
This is needed when using `helm template` in the CD tool
to ensure the resources are created in the right namespace