### PR TITLE
Add support to pull docker image from internal registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ helm install --name=kafka-minion kafka-minion/kafka-minion
 | `priorityClassName` | Priority Class to be used by the pod | `""` |
 | `podSecurityPolicy.enabled` | Enable/disable PodSecurityPolicy and associated Role/Rolebinding creation | `false` |
 | `serviceAccount.create` | Create a ServiceAccount for the pod | `false` |
+| `serviceAccount.imagePullSecrets` | Image pull secrets that should be configured on the service account | `[]` |
 | `serviceAccount.name` | Name of a ServiceAccount to use that is not handled by this chart | `default` |
 
 ## SASL/SSL Setup

--- a/kafka-minion/templates/serviceaccount.yaml
+++ b/kafka-minion/templates/serviceaccount.yaml
@@ -9,4 +9,10 @@ metadata:
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.serviceAccount.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/kafka-minion/values.yaml
+++ b/kafka-minion/values.yaml
@@ -124,6 +124,7 @@ serviceMonitor:
 # Name allows using a service account not handled by the chart
 serviceAccount:
   create: false
+  imagePullSecrets: []
   name: default
 
 # Creates a PodSecurityPolicy and the role/rolebinding


### PR DESCRIPTION
Optionally configure `imagePullSecrets` for the ServiceAccount.
The parameter can be set either as a key in Values.serviceAccount or globally in `imagePullSecrets`
The global support comes handy when this chart is used a sub-chart in larger deployments