### PR TITLE
Add brokers secret variable to support external secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ helm install --name=kafka-minion kafka-minion/kafka-minion
 | `podSecurityContext.fsGroup` | User group to use for the pod | `99` |
 | `containerSecurityContext` | Security Context for the kafka minion container | `{}` |
 | `kafka.brokers` | Comma delimited list of brokers to connect to | (none) |
+| `kafka.existingBrokersSecret` | Secret name containing the kafka brokers by key `kafka.brokers` | (none) |
 | `kafka.sasl.enabled` | Bool to enable/disable SASL authentication (only SASL_PLAINTEXT is supported) | `false` |
 | `kafka.sasl.useHandshake` | Whether or not to send the Kafka SASL handshake first | `true` |
 | `kafka.sasl.credentials.existingSecret` | Secretname of an existing secret which contains SASL credentials | (none) |

--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -73,7 +73,14 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
             - name: KAFKA_BROKERS
+              {{- if not .Values.kafka.existingBrokersSecret }}
               value: {{ required "A valid entry for kafka.brokers is required" .Values.kafka.brokers | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.kafka.existingBrokersSecret }}
+                  key: kafka.brokers
+              {{- end }}
             - name: KAFKA_CONSUMER_OFFSETS_TOPIC_NAME
               value: {{ .Values.kafka.consumerOffsetsTopic | quote }}
             {{- if .Values.kafka.sasl.enabled }}

--- a/kafka-minion/values.yaml
+++ b/kafka-minion/values.yaml
@@ -77,6 +77,7 @@ exporter:
 
 kafka:
   # brokers: kafka-1:9092, kafka-2:9092
+  # existingBrokersSecret:
   consumerOffsetsTopic: __consumer_offsets
   sasl:
     enabled: false


### PR DESCRIPTION
**Background**
We provision our Kafka with Terraform and store the broker hosts in the [AWS Parameter Store](https://docs.aws.amazon.com/de_de/systems-manager/latest/userguide/sysman-paramstore-walk.html). With [external secrets](https://github.com/godaddy/kubernetes-external-secrets), we are able to load these broker URLs directly from the Parameter Store by using Kubernetes Secrets. Whenever we apply changes with Terraform that change the Kafka Brokers, the pods that are automatically restarted (and reloaded) with the new broker hosts without any manual action. 

**Feature**
For making advantage of this automatic reload-feature, it would be great if we could load the brokers over an existing secret. This pull request contains therefore an additional parameter `kafka.existingBrokersSecret` to load the brokers by an existing secret. 

**Example Usage**

```yaml
# Chart.yaml
apiVersion: v2
name: kafka-minion
version: 0.1.0
description: Customized version of Kafka Minion
dependencies:
- name: kafka-minion
  version: "1.4.0"                  # 1.4.0 after new release :-) 
  repository: "https://raw.githubusercontent.com/cloudworkz/kafka-minion-helm-chart/master"
```

```yaml
# values.yaml
kafka-minion:
  kafka:
    existingBrokersSecret: kafka-minion-brokers
```

```yaml
# templates/secrets.yaml
apiVersion: 'kubernetes-client.io/v1'
kind: ExternalSecret
metadata:
  name: {{ index .Values "kafka-minion" "kafka" "existingBrokersSecret" }}
  labels:
    app: {{ .Release.Name }}
spec:
  backendType: systemManager
  data:
    - key: "/message-bus/KAFKA_BROKERS"
      name: kafka.brokers
```

