### PR TITLE
update medata labels & annotations

### DIFF
--- a/kafka-minion/Chart.yaml
+++ b/kafka-minion/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kafka-minion
-version: 1.4.0
+version: 1.4.1

--- a/kafka-minion/templates/deployment.yaml
+++ b/kafka-minion/templates/deployment.yaml
@@ -4,10 +4,16 @@ metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.deploymentLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,7 +24,7 @@ spec:
     metadata:
       annotations:
         {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if not .Values.serviceMonitor.create }}
         prometheus.io/scrape: "true"
@@ -28,6 +34,15 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Values.image.tag }}
+        app.kubernetes.io/component: {{ .Values.componentOverride }}
+        app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.serviceAccount.create  }}
       serviceAccountName: {{ include "kafka-minion.fullname" . }}

--- a/kafka-minion/templates/ingress.yaml
+++ b/kafka-minion/templates/ingress.yaml
@@ -7,10 +7,16 @@ metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/kafka-minion/templates/podsecuritypolicies.yaml
+++ b/kafka-minion/templates/podsecuritypolicies.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   privileged: false

--- a/kafka-minion/templates/role.yaml
+++ b/kafka-minion/templates/role.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups: ['extensions']

--- a/kafka-minion/templates/rolebinding.yaml
+++ b/kafka-minion/templates/rolebinding.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/kafka-minion/templates/service.yaml
+++ b/kafka-minion/templates/service.yaml
@@ -3,11 +3,21 @@ kind: Service
 metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.service.labels }}
+      {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/kafka-minion/templates/serviceaccount.yaml
+++ b/kafka-minion/templates/serviceaccount.yaml
@@ -5,9 +5,12 @@ metadata:
   name: {{ include "kafka-minion.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     helm.sh/chart: {{ include "kafka-minion.chart" . }}
+    app.kubernetes.io/name: {{ include "kafka-minion.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.image.tag }}
+    app.kubernetes.io/component: {{ .Values.componentOverride }}
+    app.kubernetes.io/part-of: {{ .Values.componentPartOfOverride }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:

--- a/kafka-minion/values.yaml
+++ b/kafka-minion/values.yaml
@@ -11,13 +11,18 @@ image:
 
 nameOverride: ""
 fullnameOverride: ""
+componentOverride: ""
+componentPartOfOverride: ""
 
 service:
   type: ClusterIP
   port: 8080
+  labels: {}
+  annotations: {}
 
 ingress:
   enabled: false
+  labels: {}
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -132,3 +137,7 @@ serviceAccount:
 # allowing the serviceaccount to use it
 podSecurityPolicy:
   enabled: false
+
+podsLabels: {}
+podsAnnotations: {}
+deploymentLabels: {}


### PR DESCRIPTION
Following these two documentations, https://helm.sh/docs/chart_template_guide/builtin_objects/ , https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ , we based lot of prometheus logics on labels and annotations provide by kubernetes.

I included the capacity to user to add custom annotations and labels on differents part of this helm chart.

Thx